### PR TITLE
Optimizations for lit directives

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,24 +76,19 @@ import {VirtualList} from './virtual-list.js';
 
 ```
 
-### `list` directive (lit-html)
+### `verticalList` directive (lit-html)
 
 ```js 
 import Layout from './layouts/layout-1d.js';
-import {list} from './flavors/lit-html/lit-list.js';
+import {verticalList} from './flavors/lit-html/lit-list.js';
 import {html, render} from '../../lit-html/lit-html.js';
 
 (async () => {
 
-  const layout = new Layout({direction: 'vertical'});
   const items = await fetch('./examples/contacts/contacts.json').then(response => response.json());
 
-  render(html`${list({
-    items,
-    layout,
-    template: (item, idx) => 
-      html`<section><h3>${idx} - ${item.name}</h3><p>${item.mediumText}</p></section>`,
-  })}`, document.body);
+  render(html`${verticalList(items, (item, idx) => 
+      html`<section><h3>${idx} - ${item.name}</h3><p>${item.mediumText}</p></section>`)}`, document.body);
 
 })();
 

--- a/lit-html/lit-incremental-repeater.js
+++ b/lit-html/lit-incremental-repeater.js
@@ -1,6 +1,20 @@
 import {IncrementalRepeats} from '../incremental-repeater.js';
-import {LitMixin, repeat as baseRepeat} from './lit-repeater.js';
+import {LitMixin} from './lit-repeater.js';
+import {directive} from '../../lit-html/lit-html.js';
 
 export const LitIncrementalRepeater = LitMixin(IncrementalRepeats(class{}));
 
-export const repeat = (config) => baseRepeat(config, LitIncrementalRepeater);
+const partToRepeater = new WeakMap();
+export const repeat = (config = {}) => directive(part => {
+    let repeater = partToRepeater.get(part);
+    if (!repeater) {
+        repeater = new LitIncrementalRepeater();
+        partToRepeater.set(part, repeater);
+    }
+    Object.assign(config, {
+        part,
+        // Assign template only once.
+        template: repeater.template || config.template,
+    });
+    Object.assign(repeater, config);
+});

--- a/lit-html/lit-list.js
+++ b/lit-html/lit-list.js
@@ -1,15 +1,27 @@
+import Layout from '../layouts/layout-1d.js';
 import {VirtualList} from '../virtual-list.js';
-import {LitMixin, repeat} from './lit-repeater.js';
+import {LitMixin} from './lit-repeater.js';
 import {directive} from '../../lit-html/lit-html.js';
-
-const partToList = new WeakMap();
 
 export const LitList = LitMixin(VirtualList);
 
-export const list = (config) => {
-  // Recycle by default.
-  if (config && !config.hasOwnProperty('recycle')) {
-    config.recycle = true;
-  }
-  return repeat(config, LitList);
-};
+const partToList = new WeakMap();
+export const list = (config = {}) => directive(part => {
+    let list = partToList.get(part);
+    if (!list) {
+        list = new LitList();
+        partToList.set(part, list);
+    }
+    Object.assign(config, {
+      part,
+      // Assign template only once.
+      template: list.template || config.template,
+      // Default layout.
+      layout: (config.layout || list.layout || new Layout()),
+      // Recycle by default.
+      recycle: Boolean(config.hasOwnProperty('recycle') === false || config.recycle),
+  });
+  Object.assign(list, config);
+});
+
+export const verticalList = (items, template) => list({items, template});

--- a/lit-html/lit-repeater.js
+++ b/lit-html/lit-repeater.js
@@ -1,8 +1,6 @@
 import {VirtualRepeater} from '../virtual-repeater.js';
 import {directive, NodePart} from '../../lit-html/lit-html.js';
 
-const partToRepeater = new WeakMap();
-
 export const LitMixin = Superclass => class extends Superclass {
     constructor() {
         super();
@@ -144,12 +142,17 @@ export const LitMixin = Superclass => class extends Superclass {
 
 export const LitRepeater = LitMixin(VirtualRepeater);
 
-export const repeat = (config, RepeaterClass = LitRepeater) => directive(part => {
-    Object.assign(config, {part});
+const partToRepeater = new WeakMap();
+export const repeat = (config = {}) => directive(part => {
     let repeater = partToRepeater.get(part);
     if (!repeater) {
-        repeater = new RepeaterClass();
+        repeater = new LitRepeater();
         partToRepeater.set(part, repeater);
     }
+    Object.assign(config, {
+        part,
+        // Assign template only once.
+        template: repeater.template || config.template,
+    });
     Object.assign(repeater, config);
 });


### PR DESCRIPTION
Once repeater has a template, keep that one.

Assign a default layout to list repeater if not passed.

Export `verticalList` directive which is has the same signature as `render` of lit-html
