### PR TITLE
setters for new/update/recycleChild

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,30 +1,46 @@
-# Virtual list
+# &lt;virtual-list&gt;
 
-Implementation of a Virtual list API, influenced by the research done by the [infinite list study group](https://github.com/domenic/infinite-list-study-group).
+`<virtual-list>` renders only the visible portion of a list and optimizes the amount of DOM operations and reflows.
 
-## Local Setup
+## Properties
 
-Ensure you have installed the npm dependencies and serve from the project root
-```sh
-$ npm install
-$ polymer serve --npm
-```
-Then, navigate to the url: http://localhost:8081/components/virtual-list/
+- _newChild_
+  - type: `function(item: any, index: number) => Element`
+  - returns an `Element` for the given item and index.
+- _updateChild_
+  - type: `function(child: Element, item: any, index: number)`
+  - invoked after the `child` is appended to the DOM and requires to be updated with data.
+- _recycleChild_
+  - type: `function(child: Element, item: any, index: number)`
+  - invoked before the `child` is removed from the DOM. Set to control DOM removal/recycling behavior.
+- _items_
+  - type: `Array`
+  - the data model.
+- _layout_ 
+  - type: `string`
+  - layout type, can be set via attribute or property to "vertical" (default) or "horizontal".
 
-## Concepts and Domain
 
-An infinite list optimizes the rendering of DOM according to the visible area and available data.
+## Methods
 
-Some implementations append DOM incrementally, others recycle the DOM.
+- _requestReset()_
+  - Schedules a rerendering of the displayed items.
 
-## &lt;virtual-list&gt;
+## Events
 
-`<virtual-list>` can be configured through 3 properties:
-- `items (Array)`, the data model.
-- `template (Function|Object)`, generates the DOM for each data item. Can be set only once.
-- `direction (string)` (optional), layout direction, can be set via attribute or property to "vertical" (default) or "horizontal".
+- _rangechange_
+  - `bubbles: false, cancelable: false, composed: false`
+  - Fired when the list has scrolled to a new range of items.
+  - _event.detail.first_
+    - type: `number`
+    - the index of the first item currently rendered.
+  - _event.detail.num_
+    - type: `number`
+    - the number of items currently rendered.
 
-Minimal setup:
+
+## Minimal setup
+ 
 ```html
 <virtual-list></virtual-list>
 
@@ -35,16 +51,15 @@ Minimal setup:
 
   list.items = new Array(20).fill({name: 'item'});
 
-  list.template = (item, index) => {
+  list.newChild = (item, index) => {
     const child = document.createElement('section');
     child.textContent = index + ' - ' + item.name;
     return child;
   };
-  
 </script>
 ```
 
-`template` can be also set as an `{newChild: Function, updateChild: Function, recycleChild: Function}` object.
+## DOM recycling
 
 You can recycle DOM by using the `recycleChild` function to collect DOM, and reuse it in `newChild`.
 
@@ -53,7 +68,7 @@ If you decide to keep the recycled DOM attached in the main document, perform DO
 ```js
 const recycled = [];
 
-list.template = {
+Object.assign(list, {
   newChild: (item, index) => {
     return recycled.pop() || document.createElement('section');
   },
@@ -66,32 +81,46 @@ list.template = {
 };
 ```
 
+## Data manipulation
+
 Updates to the `items` array instance will not be captured by `<virtual-list>`.
 
 Either set a new array to trigger the update, or use `requestReset()` to notify of changes if you want to keep the same array instance.
 ```js
+/* Set a new array instance to trigger rerendering. */
 list.items = list.items.concat([{name: 'new item'}]);
 
+/* 
+  If you want to keep the same array instance, remember to 
+  invoke `requestReset()` to notify of the changes.
+ */
 list.items.push({name: 'new item'});
 list.requestReset();
 ```
 
-### `virtualList(items, template, direction)` directive (lit-html)
+## Range changes
 
-`virtualList` directive can be configured with 3 properties:
-- `items (Array)`, the data model.
-- `template (Function)`, generates the DOM for each data item.
-- `direction (string)` (optional), layout direction, can be set to "vertical" (default) or "horizontal".
-
+Listen for `rangechange` event to get notified of changes of `first, num`.
 ```js
-const render = () => html`
-  <ul>
-    ${virtualList(items, (i, index) => html`
-      <li>${index}: ${i.name}</li>`)}
-  </ul>
-`;
+list.addEventListener('rangechange', (event) => {
+  const range = event.detail;
+  if (range.first + range.num === list.items.length) {
+    console.log('scrolled to the bottom of the list!');
+  }
+});
 ```
 
-## Design
+# Development
+
+Implementation of a Virtual list API, influenced by the research done by the [infinite list study group](https://github.com/domenic/infinite-list-study-group).
+
+Ensure you have installed the npm dependencies and serve from the project root
+```sh
+$ npm install
+$ polymer serve --npm
+```
+Then, navigate to the url: http://localhost:8081/components/virtual-list/
+
+### Design
 
 See [DESIGN.md](./DESIGN.md) for more details.

--- a/README.md
+++ b/README.md
@@ -30,17 +30,16 @@
 
 - _rangechange_
   - `bubbles: false, cancelable: false, composed: false`
-  - Fired when the list has scrolled to a new range of items.
+  - Fired when the list has rendered to a new range of items.
   - _event.detail.first_
     - type: `number`
     - the index of the first item currently rendered.
-  - _event.detail.num_
+  - _event.detail.last_
     - type: `number`
-    - the number of items currently rendered.
+    - the index of the last item currently rendered.
 
+# Example
 
-## Minimal setup
- 
 ```html
 <virtual-list></virtual-list>
 
@@ -49,13 +48,13 @@
 
   const list = document.querySelector('virtual-list');
 
-  list.items = new Array(20).fill({name: 'item'});
-
   list.newChild = (item, index) => {
     const child = document.createElement('section');
     child.textContent = index + ' - ' + item.name;
     return child;
   };
+
+  list.items = new Array(20).fill({name: 'item'});
 </script>
 ```
 
@@ -100,12 +99,15 @@ list.requestReset();
 
 ## Range changes
 
-Listen for `rangechange` event to get notified of changes of `first, num`.
+Listen for `rangechange` event to get notified when the displayed items range changes.
 ```js
 list.addEventListener('rangechange', (event) => {
   const range = event.detail;
-  if (range.first + range.num === list.items.length) {
-    console.log('scrolled to the bottom of the list!');
+  if (range.first === 0) {
+    console.log('rendered first item.');
+  }
+  if (range.last === list.items.length - 1) {
+    console.log('rendered last item.');
   }
 });
 ```

--- a/demo/html-spec/html-spec-viewer.js
+++ b/demo/html-spec/html-spec-viewer.js
@@ -11,19 +11,21 @@ class HTMLSpecViewer extends VirtualListElement {
       this.appendChild(this._htmlSpec.head);
 
       this.items = [];
-      this.template = (item) => item;
-      this.addEventListener('stable', () => this._onStable());
-      this._addNextChunk();
+      this.addNextChunk();
+      this.addEventListener(
+          'rangechange', (event) => this.onRangechange(event.detail));
     }
   }
 
-  _onStable() {
-    if (this.first + this.num >= this.items.length - 4) {
-      this._addNextChunk();
-    }
+  newChild(item) {
+    return item;
   }
 
-  async _addNextChunk(chunk = 10) {
+  recycleChild() {
+    // keep children in DOM.
+  }
+
+  async addNextChunk(chunk = 10) {
     if (this._adding) {
       return;
     }
@@ -42,6 +44,12 @@ class HTMLSpecViewer extends VirtualListElement {
       }
     }
     this._adding = false;
+  }
+
+  onRangechange(range) {
+    if (range.first + range.num >= this.items.length - 4) {
+      this.addNextChunk();
+    }
   }
 }
 

--- a/demo/html-spec/html-spec-viewer.js
+++ b/demo/html-spec/html-spec-viewer.js
@@ -47,7 +47,7 @@ class HTMLSpecViewer extends VirtualListElement {
   }
 
   onRangechange(range) {
-    if (range.first + range.num >= this.items.length - 4) {
+    if (range.last >= this.items.length - 4) {
       this.addNextChunk();
     }
   }

--- a/lit-html/README.md
+++ b/lit-html/README.md
@@ -1,0 +1,15 @@
+# `virtualList(items, template, direction)` directive (lit-html)
+
+`virtualList` directive can be configured with 3 properties:
+- `items (Array)`, the data model.
+- `template (Function)`, generates the DOM for each data item.
+- `direction (string)` (optional), layout direction, can be set to "vertical" (default) or "horizontal".
+
+```js
+const render = () => html`
+  <ul>
+    ${virtualList(items, (i, index) => html`
+      <li>${index}: ${i.name}</li>`)}
+  </ul>
+`;
+```

--- a/virtual-list-element.js
+++ b/virtual-list-element.js
@@ -40,12 +40,12 @@ export class VirtualListElement extends HTMLElement {
   }
 
   static get observedAttributes() {
-    return ['direction'];
+    return ['layout'];
   }
 
   attributeChangedCallback(name, oldVal, newVal) {
-    if (name === 'direction') {
-      this.direction = newVal;
+    if (name === 'layout') {
+      this.layout = newVal;
     }
   }
 
@@ -91,14 +91,6 @@ export class VirtualListElement extends HTMLElement {
       this[_items] = items;
       this[_render]();
     }
-  }
-
-  get first() {
-    return this[_list] ? this[_list].first : 0;
-  }
-
-  get num() {
-    return this[_list] ? this[_list].num : 0;
   }
 
   requestReset() {

--- a/virtual-list.js
+++ b/virtual-list.js
@@ -217,8 +217,9 @@ export const RepeatsAndScrolls = Superclass => class extends Repeats
    */
   _notifyStable() {
     const {first, num} = this;
+    const last = first + num;
     this._container.dispatchEvent(
-        new CustomEvent('rangechange', {detail: {first, num}}));
+        new CustomEvent('rangechange', {detail: {first, last}}));
   }
 };
 


### PR DESCRIPTION
Fixes #18, fixes #20.

README.md made `<virtual-list>` centric, documented all APIs.

`<virtual-list>`:
- added `newChild, updateChild, recycleChild` properties
- renamed `direction` to `layout`; we already have a GridLayout implementation, so in case we decide to expose it, it makes more sense to have this property named as layout

`VirtualRepeater`:
- only `container` required in the constructor config, other properties can be set later on via setters

`VirtualList`:
- `layout` can be set via constructor args or via setter.
- renamed `stable` to `rangechange` and pass `first, last` in the `event.detail`